### PR TITLE
Add in "Check for updates" button

### DIFF
--- a/16x9/AddonBrowser.xml
+++ b/16x9/AddonBrowser.xml
@@ -138,6 +138,11 @@
 					<label>25000</label>
 					<visible>Control.IsEnabled(6)</visible>
 				</control>
+				<!-- Check for updates -->
+				<control type="button" id="9">
+					<include>ButtonCommonValues</include>
+					<label>24034</label>
+				</control>
 				<!-- Language -->
 				<control type="radiobutton" id="7">
 					<include>OptionButtons</include>


### PR DESCRIPTION
I understand that there's a full OSMC update, but this hasn't run the full addons update check that seems to only happen manually.  People should have the option to run the check themselves, when they want, like they can in the default, Confluence skin.
