### PR TITLE
Provide additional larger font sets for small screens

### DIFF
--- a/16x9/Font.xml
+++ b/16x9/Font.xml
@@ -84,4 +84,88 @@
 			<size>21</size>
 		</font>
 	</fontset>
+	<fontset id="Default +10">
+		<font>
+			<name>XLarge</name>
+			<filename>NotoSans-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>58</size>
+		</font>
+		<font>
+			<name>Large</name>
+			<filename>NotoSans-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>53</size>
+		</font>
+		<font>
+			<name>Med</name>
+			<filename>NotoSans-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>48</size>
+		</font>
+		<font>
+			<name>Small</name>
+			<filename>NotoSans-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>43</size>
+		</font>
+		<font>
+			<name>XSmall</name>
+			<filename>NotoSans-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>38</size>
+		</font>
+		<!-- Required for system -->
+		<font>
+			<name>font13</name>
+			<filename>Arial.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>31</size>
+		</font>
+	</fontset>
+	<fontset id="Arial +10">
+		<font>
+			<name>XLarge</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>58</size>
+		</font>
+		<font>
+			<name>Large</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>53</size>
+		</font>
+		<font>
+			<name>Med</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>48</size>
+		</font>
+		<font>
+			<name>Small</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>43</size>
+		</font>
+		<font>
+			<name>XSmall</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>38</size>
+		</font>
+		<!-- Required for system -->
+		<font>
+			<name>font13</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>31</size>
+		</font>
+	</fontset>
 </fonts>


### PR DESCRIPTION
To improve readability on smaller screens I've copied the two fontsets "Default" and "Arial" and created two additional ones "Default +10" and "Arial +10" which are 10pt bigger.

The skin's layout stays intact, everything looks fine on my 35cm TV in the bedroom.
